### PR TITLE
Implement smartphone drawing to sound webapp

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,5 @@
+# Lousa Musical
+
+Este web app permite desenhar em uma lousa usando dispositivos com tela sensível ao toque (por exemplo, smartphones). O desenho é convertido em som: a coordenada vertical de cada ponto determina a frequência entre 220 Hz (A3) e 880 Hz (A5). Após soltar o dedo/cursor, o som correspondente é reproduzido e uma explicação aparece abaixo.
+
+Para testar basta abrir `index.html` em um navegador moderno com suporte a WebAudio.

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lousa Musical</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Lousa Musical</h1>
+<canvas id="board" width="300" height="300"></canvas>
+<div id="info"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -1,0 +1,56 @@
+const canvas = document.getElementById('board');
+const ctx = canvas.getContext('2d');
+const info = document.getElementById('info');
+let drawing = false;
+let points = [];
+
+// audio context
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+function getFrequency(y) {
+    const minFreq = 220; // A3
+    const maxFreq = 880; // A5
+    const ratio = 1 - y / canvas.height;
+    return minFreq + (maxFreq - minFreq) * ratio;
+}
+
+function playSound(path) {
+    let startTime = audioCtx.currentTime;
+    path.forEach((p, i) => {
+        const osc = audioCtx.createOscillator();
+        osc.type = 'sine';
+        osc.frequency.value = getFrequency(p.y);
+        osc.connect(audioCtx.destination);
+        const duration = 0.1;
+        osc.start(startTime + i * duration);
+        osc.stop(startTime + (i + 1) * duration);
+    });
+}
+
+canvas.addEventListener('pointerdown', e => {
+    drawing = true;
+    points = [];
+    ctx.beginPath();
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    ctx.moveTo(x, y);
+    points.push({x, y});
+});
+
+canvas.addEventListener('pointermove', e => {
+    if (!drawing) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    points.push({x, y});
+});
+
+canvas.addEventListener('pointerup', () => {
+    drawing = false;
+    playSound(points);
+    const explanation = `O desenho foi convertido em som associando a posicao vertical de cada ponto a uma frequencia entre 220 Hz e 880 Hz. Assim, partes mais altas soam mais agudas.`;
+    info.textContent = explanation;
+});

--- a/webapp/style.css
+++ b/webapp/style.css
@@ -1,0 +1,23 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+h1 {
+    font-size: 1.5rem;
+}
+
+#board {
+    border: 1px solid #000;
+    touch-action: none; /* allow drawing on touch devices */
+}
+
+#info {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    max-width: 300px;
+}


### PR DESCRIPTION
## Summary
- add simple smartphone-ready web app in `webapp/`
- map drawing to sound and provide explanation for each drawing

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684154fc39dc832d87ab3b4ce65a3a58