### PR TITLE
Improve drawing to waveform playback

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,8 @@
+# Lousa Musical
+
+Este web app permite desenhar em uma lousa usando dispositivos com tela sensível ao toque (por exemplo, smartphones).
+O contorno desenhado é interpretado como uma forma de onda de 1 segundo: o eixo horizontal representa o tempo e o eixo vertical, a amplitude da onda variando entre -1 e 1.
+Ao soltar o dedo ou cursor, a forma de onda é reproduzida e uma explicação científica é exibida abaixo.
+O botão **Limpar** remove o desenho e permite recomeçar.
+
+Para testar basta abrir `index.html` em um navegador moderno com suporte a WebAudio.

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Lousa Musical</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<h1>Lousa Musical</h1>
+<canvas id="board" width="300" height="300"></canvas>
+<button id="clear">Limpar</button>
+<div id="info"></div>
+<script src="script.js"></script>
+</body>
+</html>

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -1,0 +1,86 @@
+const canvas = document.getElementById('board');
+const ctx = canvas.getContext('2d');
+const info = document.getElementById('info');
+const clearBtn = document.getElementById('clear');
+
+let drawing = false;
+let points = [];
+
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
+function drawToWave(path) {
+    const width = canvas.width;
+    const height = canvas.height;
+    const sampleRate = audioCtx.sampleRate;
+    const duration = 1; // seconds
+    const sampleCount = sampleRate * duration;
+    const temp = new Float32Array(width).fill(height / 2);
+
+    for (let i = 0; i < path.length - 1; i++) {
+        const p0 = path[i];
+        const p1 = path[i + 1];
+        const dx = p1.x - p0.x;
+        const steps = Math.max(Math.abs(dx), 1);
+        for (let s = 0; s <= steps; s++) {
+            const t = s / steps;
+            const x = Math.round(p0.x + dx * t);
+            const y = p0.y + (p1.y - p0.y) * t;
+            if (x >= 0 && x < width) {
+                temp[x] = y;
+            }
+        }
+    }
+
+    const buffer = audioCtx.createBuffer(1, sampleCount, sampleRate);
+    const channel = buffer.getChannelData(0);
+    for (let i = 0; i < sampleCount; i++) {
+        const x = i * width / sampleCount;
+        const idx = Math.floor(x);
+        const nextIdx = Math.min(idx + 1, width - 1);
+        const frac = x - idx;
+        const y = temp[idx] + (temp[nextIdx] - temp[idx]) * frac;
+        channel[i] = (height / 2 - y) / (height / 2);
+    }
+    return buffer;
+}
+
+function playBuffer(buffer) {
+    const src = audioCtx.createBufferSource();
+    src.buffer = buffer;
+    src.connect(audioCtx.destination);
+    src.start();
+}
+
+canvas.addEventListener('pointerdown', e => {
+    drawing = true;
+    points = [];
+    ctx.beginPath();
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    ctx.moveTo(x, y);
+    points.push({ x, y });
+});
+
+canvas.addEventListener('pointermove', e => {
+    if (!drawing) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    ctx.lineTo(x, y);
+    ctx.stroke();
+    points.push({ x, y });
+});
+
+canvas.addEventListener('pointerup', () => {
+    drawing = false;
+    if (points.length < 2) return;
+    const buffer = drawToWave(points);
+    playBuffer(buffer);
+    info.textContent = `A forma desenhada foi interpretada como uma onda sonora de 1 segundo. O eixo x representa o tempo e o eixo y a amplitude entre -1 e 1. A onda é reproduzida a ${audioCtx.sampleRate} Hz.`;
+});
+
+clearBtn.addEventListener('click', () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    info.textContent = '';
+});

--- a/webapp/style.css
+++ b/webapp/style.css
@@ -1,0 +1,28 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+h1 {
+    font-size: 1.5rem;
+}
+
+#board {
+    border: 1px solid #000;
+    touch-action: none; /* allow drawing on touch devices */
+}
+
+#clear {
+    margin-top: 0.5rem;
+    padding: 0.25rem 0.5rem;
+}
+
+#info {
+    margin-top: 1rem;
+    padding: 0.5rem;
+    max-width: 300px;
+}


### PR DESCRIPTION
## Summary
- update README with updated instructions
- add clear button to the page
- generate a waveform from the drawing and play it

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684154fc39dc832d87ab3b4ce65a3a58