### PR TITLE
Enable mouse support

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,8 +1,8 @@
 # Lousa Musical
 
-Este web app permite desenhar em uma lousa usando dispositivos com tela sensível ao toque (por exemplo, smartphones).
+Este web app permite desenhar em uma lousa utilizando dispositivos com tela sensível ao toque ou com mouse.
 O contorno desenhado é interpretado como uma forma de onda de 1 segundo: o eixo horizontal representa o tempo e o eixo vertical, a amplitude da onda variando entre -1 e 1.
 Ao soltar o dedo ou cursor, a forma de onda é reproduzida e uma explicação científica é exibida abaixo.
 O botão **Limpar** remove o desenho e permite recomeçar.
 
-Para testar basta abrir `index.html` em um navegador moderno com suporte a WebAudio.
+Para testar basta abrir `index.html` em um navegador moderno com suporte a WebAudio, tanto em dispositivos móveis quanto em computadores pessoais.

--- a/webapp/script.js
+++ b/webapp/script.js
@@ -51,34 +51,46 @@ function playBuffer(buffer) {
     src.start();
 }
 
-canvas.addEventListener('pointerdown', e => {
+function getPos(evt) {
+    const rect = canvas.getBoundingClientRect();
+    const clientX = evt.touches ? evt.touches[0].clientX : evt.clientX;
+    const clientY = evt.touches ? evt.touches[0].clientY : evt.clientY;
+    return { x: clientX - rect.left, y: clientY - rect.top };
+}
+
+function startDraw(e) {
+    e.preventDefault();
     drawing = true;
     points = [];
     ctx.beginPath();
-    const rect = canvas.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+    const { x, y } = getPos(e);
     ctx.moveTo(x, y);
     points.push({ x, y });
-});
+}
 
-canvas.addEventListener('pointermove', e => {
+function moveDraw(e) {
     if (!drawing) return;
-    const rect = canvas.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
+    e.preventDefault();
+    const { x, y } = getPos(e);
     ctx.lineTo(x, y);
     ctx.stroke();
     points.push({ x, y });
-});
+}
 
-canvas.addEventListener('pointerup', () => {
+function endDraw() {
     drawing = false;
     if (points.length < 2) return;
     const buffer = drawToWave(points);
     playBuffer(buffer);
     info.textContent = `A forma desenhada foi interpretada como uma onda sonora de 1 segundo. O eixo x representa o tempo e o eixo y a amplitude entre -1 e 1. A onda é reproduzida a ${audioCtx.sampleRate} Hz.`;
-});
+}
+
+['pointerdown', 'mousedown', 'touchstart'].forEach(evt =>
+    canvas.addEventListener(evt, startDraw));
+['pointermove', 'mousemove', 'touchmove'].forEach(evt =>
+    canvas.addEventListener(evt, moveDraw));
+['pointerup', 'mouseup', 'touchend', 'touchcancel'].forEach(evt =>
+    canvas.addEventListener(evt, endDraw));
 
 clearBtn.addEventListener('click', () => {
     ctx.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
## Summary
- allow drawing with mouse or touch
- clarify README that PCs are supported

## Testing
- `node -c webapp/script.js`
- `node -e "const fs=require('fs');console.log(/getPos/.test(fs.readFileSync('webapp/script.js','utf8')));"`

------
https://chatgpt.com/codex/tasks/task_e_684504f4fb28832da2aff064191c3f6a